### PR TITLE
grbl meta: move from 9 byte to 8 byte encoding

### DIFF
--- a/setup_ubuntu_20.04.sh
+++ b/setup_ubuntu_20.04.sh
@@ -27,7 +27,7 @@ sudo apt-get install -y python3-pip
 
 install_pyuscope() {
     sudo apt-get install -y python3-gst-1.0 python3-gi python3-pyqt5 python3-usb python3-opencv python3-serial python3-numpy python3-scipy imagemagick
-    sudo pip3 install json5 boto3 pygame psutil
+    sudo pip3 install json5 boto3 pygame psutil bitarray
 
 
     # Ubuntu 20.04

--- a/test/grbl/write_meta.py
+++ b/test/grbl/write_meta.py
@@ -54,7 +54,7 @@ def main():
         if comment is None:
             comment = info.get("comment")
         if config is None:
-            config = info.get("config", b"\x00\x00\x00\x00")
+            config = info.get("config")
         print("Writing")
         grbl_write_meta(grbl.gs, comment=comment, sn=sn, config=config)
 


### PR DESCRIPTION
Fixes https://github.com/Labsmore/pyuscope/issues/357

NOTE: this is a breaking change. Metadata will need to be re-written. This isn't in significant deployment right now, so not going to automatically migrate it. Users will need to issue a low level command to migrate it