### PR TITLE
Fix random '=2.2.2' file creation.

### DIFF
--- a/setup_ubuntu_20.04.sh
+++ b/setup_ubuntu_20.04.sh
@@ -36,7 +36,7 @@ install_pyuscope() {
 
     # For webserver
     sudo apt-get install -y python3-werkzeug
-    pip3 install --user Flask>=2.2.2
+    pip3 install --user 'Flask>=2.2.2'
 
     sudo python3 setup.py develop
 }


### PR DESCRIPTION
Currently the `setup_ubuntu_20.04.sh` script will create a `=2.2.2` file in the directory as bash sees the `>` as a redirect.