### PR TITLE
[codex] Fix obvious pyuscope bugs

### DIFF
--- a/uscope/app/argus/threads.py
+++ b/uscope/app/argus/threads.py
@@ -117,7 +117,7 @@ class StitcherThread(CommandThreadBase, ArgusThread):
             j["cs_info"] = cs_info
         self.command("imagep", j, block=block)
 
-    def process_run(self, args, variant, directory_comment):
+    def process_run(self, args, variant, directory_comment, env=None):
         print("")
         print("")
         print("")
@@ -126,7 +126,8 @@ class StitcherThread(CommandThreadBase, ArgusThread):
         popen = subprocess.Popen(args,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT,
-                                 universal_newlines=True)
+                                 universal_newlines=True,
+                                 env=env)
         p = psutil.Process(popen.pid)
         # Lower priority so GUI runs smoothly
         p.nice(10)
@@ -179,21 +180,22 @@ class StitcherThread(CommandThreadBase, ArgusThread):
                 cs_auto_cli,
             ]
             if cs_info:
-                args += [
-                    "--access-key",
-                    cs_info.access_key(),
-                    "--secret-key",
-                    cs_info.secret_key(),
-                    "--id-key",
-                    cs_info.id_key(),
-                    "--notification-email",
-                    cs_info.notification_email(),
-                ]
+                env = os.environ.copy()
+                env["PYUSCOPE_CS_ACCESS_KEY"] = cs_info.access_key()
+                env["PYUSCOPE_CS_SECRET_KEY"] = cs_info.secret_key()
+                env["PYUSCOPE_CS_ID_KEY"] = cs_info.id_key()
+                env["PYUSCOPE_CS_NOTIFICATION_EMAIL"] = (
+                    cs_info.notification_email())
+            else:
+                env = None
 
             args.append(j["directory"])
             args.append("--json")
             args.append(json.dumps(ipp))
-            ok = ok and self.process_run(args, "cs_auto", j['directory'])
+            ok = ok and self.process_run(args,
+                                         "cs_auto",
+                                         j['directory'],
+                                         env=env)
 
         if ok and simple_cli:
             args = [

--- a/uscope/motion/lcnc/hal_ar.py
+++ b/uscope/motion/lcnc/hal_ar.py
@@ -14,15 +14,25 @@ except:
     print("FIXME WARNING: paramiko import failed")
     paramiko = None
 import select
+import socket
 import sys
 import threading
 import time
-import subprocess
 
-DEVNULL = open(os.devnull, 'wb')
 RSH_PORT = 5007
 
 # http://stackoverflow.com/questions/4409502/directory-transfers-on-paramiko
+
+
+def write_channel_output(channel):
+    data = channel.recv(1024)
+    if hasattr(sys.stdout, "buffer"):
+        out = sys.stdout.buffer
+        out.write(data)
+        out.flush()
+    else:
+        sys.stdout.write(data.decode(errors="replace"))
+        sys.stdout.flush()
 
 
 class LcncPyHalAr(LcncPyHal):
@@ -167,12 +177,13 @@ class LcncPyHalAr(LcncPyHal):
         LcncPyHal.__init__(self, linuxcnc=linuxcnc, **kwargs)
 
     def local_port_up(self, port):
-        rc = subprocess.call('exec 6<>/dev/tcp/127.0.0.1/%s' % port,
-                             shell=True,
-                             stdout=DEVNULL,
-                             stderr=DEVNULL,
-                             executable='/bin/bash')
-        return rc == 0
+        try:
+            sock = socket.create_connection(('127.0.0.1', int(port)),
+                                            timeout=0.5)
+            sock.close()
+            return True
+        except OSError:
+            return False
 
     def wait_local_port(self, port):
         print('Checking local port %d' % port)
@@ -202,7 +213,9 @@ class LcncPyHalAr(LcncPyHal):
         if self.tunnel:
             # ForwardServer
             self.tunnel.shutdown()
-        self.ssh.close()
+        ssh = getattr(self, "ssh", None)
+        if ssh:
+            ssh.close()
 
     def run_linuxcnc(self):
         '''
@@ -217,8 +230,7 @@ class LcncPyHalAr(LcncPyHal):
                                                     [], [])
             if len(rdy_r):
                 # TODO: consider log file instead
-                sys.stdout.write(self.linuxcnc_channel.recv(1024))
-                sys.stdout.flush()
+                write_channel_output(self.linuxcnc_channel)
 
         print('linuxcnc thread exiting')
 
@@ -243,8 +255,7 @@ class LcncPyHalAr(LcncPyHal):
                                                     [])
             if len(rdy_r):
                 # TODO: consider log file instead
-                sys.stdout.write(self.server_channel.recv(1024))
-                sys.stdout.flush()
+                write_channel_output(self.server_channel)
 
         # http://sebastiandahlgren.se/2012/10/11/using-paramiko-to-send-ssh-commands/
         # weird they didn't conform to the file api at all with fds

--- a/uscope/paramiko_util.py
+++ b/uscope/paramiko_util.py
@@ -61,7 +61,11 @@ class Handler(socketserver.BaseRequestHandler):
         self._verbose('Tunnel closed from %r' % (peername, ))
 
 
-def forward_tunnel(local_port, remote_host, remote_port, transport):
+def forward_tunnel(local_port,
+                   remote_host,
+                   remote_port,
+                   transport,
+                   local_host='127.0.0.1'):
     # this is a little convoluted, but lets me configure things for the Handler
     # object.  (SocketServer doesn't give Handlers any way to access the outer
     # server normally.)
@@ -70,8 +74,8 @@ def forward_tunnel(local_port, remote_host, remote_port, transport):
         chain_port = remote_port
         ssh_transport = transport
 
-    #ForwardServer(('', local_port), SubHander).serve_forever()
-    return ForwardServer(('', local_port), SubHander)
+    #ForwardServer((local_host, local_port), SubHander).serve_forever()
+    return ForwardServer((local_host, local_port), SubHander)
 
 
 def normalize_dirpath(dirpath):

--- a/uscope/script/webserver_api.py
+++ b/uscope/script/webserver_api.py
@@ -98,7 +98,7 @@ class Plugin(ArgusScriptingPlugin):
         elif mode == "network":
             host = "0.0.0.0"
         else:
-            assert 0, f"bad mode {host}"
+            raise ValueError(f"bad mode {mode}")
 
         vals = self.get_input()
         port = vals["port"]
@@ -113,8 +113,10 @@ class Plugin(ArgusScriptingPlugin):
             self.sleep(0.1)
 
     def cleanup(self):
-        self.server.shutdown()
-        self.server.join()
+        if getattr(self, "server", None):
+            self.server.shutdown()
+            self.server.join()
+            self.server = None
 
 
 webserver_common.make_app(app)

--- a/uscope/script/webserver_page.py
+++ b/uscope/script/webserver_page.py
@@ -44,16 +44,15 @@ from uscope.script import webserver_common
 
 from flask import Flask, current_app, request, render_template, send_from_directory
 import json
+import os
 from werkzeug.serving import make_server
-from flask_cors import CORS
 import cv2
 from flask_socketio import SocketIO
 import base64
 import numpy as np
 
-FLUTTER_WEB_DIR = "web"
+FLUTTER_WEB_DIR = os.path.join(os.path.dirname(__file__), "web")
 app = Flask(__name__, template_folder=FLUTTER_WEB_DIR)
-CORS(app)
 SERVER_PORT = 8080
 HOST = '127.0.0.1'
 
@@ -69,35 +68,37 @@ def image_to_base64(p_img):
 
 class MySocket(SocketIO):
     def __init__(self, *args, **kwargs):
-        webserver_common.plugin = self
         super().__init__(*args, **kwargs)
         self.clients = set()
         self.on_event('connect', self.on_connection)
         self.on_event('disconnect', self.on_disconnection)
 
     def on_connection(self):
-        if not self.clients:
-            self.start_background_task(self.video_feed, current_app.plugin)
+        first_client = not self.clients
         self.clients.add(request.sid)
         plugin = current_app.plugin
+        if first_client:
+            self.start_background_task(self.video_feed, plugin)
         plugin.log_verbose(
             f"Client connected: connections = {len(self.clients)}")
         self.emit('client_connected')
 
     def on_disconnection(self):
-        self.clients.remove(request.sid)
+        self.clients.discard(request.sid)
         plugin = current_app.plugin
         plugin.log_verbose(
             f"Client disconnected: connections = {len(self.clients)}")
 
     def video_feed(self, plugin):
-        while plugin.server:
+        while plugin.server and self.clients:
             image = plugin.image()
             string_data = image_to_base64(image)
             self.emit('video_feed_back', string_data)
+            self.sleep(0.1)
 
     def disconnect_clients(self):
         self.emit("disconnect")
+        self.clients.clear()
 
 
 class Plugin(ArgusScriptingPlugin):
@@ -115,10 +116,11 @@ class Plugin(ArgusScriptingPlugin):
         self.log(f"Running Pyuscope Webserver Plugin on port: {SERVER_PORT}")
         self.objectives = self._ac.microscope.get_objectives()
         if not self.socket:
-            self.socket = MySocket(app, cors_allowed_origins="*")
+            self.socket = MySocket(app)
 
         # Keep a reference to this plugin
         app.plugin = self
+        webserver_common.plugin = self
         self.server = make_server(host=HOST,
                                   port=SERVER_PORT,
                                   app=app,
@@ -149,9 +151,4 @@ def return_flutter_doc(name):
     """
     Required to serve flutter web docs
     """
-    data_list = str(name).split('/')
-    dir_name = FLUTTER_WEB_DIR
-    if len(data_list) > 1:
-        for i in range(0, len(data_list) - 1):
-            dir_name += '/' + data_list[i]
-    return send_from_directory(dir_name, data_list[-1])
+    return send_from_directory(FLUTTER_WEB_DIR, name)

--- a/utils/cal_ff_create.py
+++ b/utils/cal_ff_create.py
@@ -46,8 +46,10 @@ def average_imgs(imgs, scalar=None):
 def average_dir(din, images=0, verbose=1, scalar=None):
     imgs = []
 
-    files = list(glob.glob(os.path.join(din, "*.jpg")))
+    files = sorted(glob.glob(os.path.join(din, "*.jpg")))
     verbose and print('Reading %s w/ %u images' % (din, len(files)))
+    if not files:
+        raise ValueError("No .jpg images found in %s" % din)
 
     for fni, fn in enumerate(files):
         imgs.append(Image.open(fn))
@@ -142,20 +144,18 @@ def main():
         assert config.USC.has_default_microscope_name(
         ), "Need microscope name to auto place cal files or explicit output dir"
         dir_out = config.get_microscope_data_dir()
-    if not os.path.exists(dir_out):
-        os.mkdir(dir_out)
+    os.makedirs(dir_out, exist_ok=True)
 
     _fff, ffi = average_dir(args.dir_in, images=args.images)
     print(f"Saving images to {dir_out}")
-    fn_out_ff = dir_out + '/imager_calibration_ff.tif'
-    fn_out_ffe = dir_out + '/imager_calibration_ffe.tif'
+    fn_out_ff = os.path.join(dir_out, 'imager_calibration_ff.tif')
+    fn_out_ffe = os.path.join(dir_out, 'imager_calibration_ffe.tif')
     print(f"Saving {fn_out_ff}")
     ffi.save(fn_out_ff)
     # FIXME: find some way to generate this by CLI
     print(f"Saving {fn_out_ffe}")
     # histeq_im(ffi).save(dir_out + '/ffe.tif')
-    subprocess.check_call(f"convert {fn_out_ff} -equalize {fn_out_ffe}",
-                          shell=True)
+    subprocess.check_call(["convert", fn_out_ff, "-equalize", fn_out_ffe])
 
     if 0:
         ((ffi_rmin, ffi_rmax), (ffi_gmin, ffi_gmax),

--- a/utils/cs_auto.py
+++ b/utils/cs_auto.py
@@ -94,10 +94,12 @@ def main():
     parser.add_argument("dirs_in", nargs="*")
     args = parser.parse_args()
 
-    cs_info = CSInfo(access_key=args.access_key,
-                     secret_key=args.secret_key,
-                     id_key=args.id_key,
-                     notification_email=args.notification_email)
+    cs_info = CSInfo(
+        access_key=args.access_key or os.environ.get("PYUSCOPE_CS_ACCESS_KEY"),
+        secret_key=args.secret_key or os.environ.get("PYUSCOPE_CS_SECRET_KEY"),
+        id_key=args.id_key or os.environ.get("PYUSCOPE_CS_ID_KEY"),
+        notification_email=args.notification_email
+        or os.environ.get("PYUSCOPE_CS_NOTIFICATION_EMAIL"))
 
     j = {}
     if args.json:


### PR DESCRIPTION
## Summary
- fix web UI plugin routing, static file serving, CORS defaults, and runaway socket video loops
- bind LinuxCNC SSH tunnels to loopback and fix Python 3 channel output handling
- remove shell-built calibration commands and keep CloudStitch secrets out of subprocess argv

## Validation
- `python3 -m compileall -q uscope utils test`
- `git diff --check`
- focused `forward_tunnel` bind check

## Notes
- `python3 -m unittest discover -s test/unit -p 'test_*.py'` is blocked by missing local dependency `json5`.\n- Existing untracked `.DS_Store` files were not included.