### PR TITLE
scripts to install on debian trixie 

### DIFF
--- a/setup_debian.sh
+++ b/setup_debian.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -ex
+
+# For GRBL etc serial port
+sudo usermod -a -G dialout $USER
+
+sudo apt-get install --assume-yes \
+    python3-gst-1.0 python3-gi python3-pyqt5 python3-usb python3-serial python3-numpy \
+    python3-scipy imagemagick python3-distro python3-zbar luminance-hdr \
+    libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev gir1.2-gst-rtsp-server-1.0 \
+    hugin-tools enfuse \
+    python3-werkzeug \
+    python3-venv python3-pip \
+    python3-opencv
+
+sudo apt install --assume-yes cmake
+
+sudo apt install --assume-yes python3-gi python3-gi-cairo gir1.2-gtk-4.0
+
+sudo apt install --assume-yes libcairo2-dev libgirepository1.0-dev pkg-config
+
+sudo apt install --assume-yes libgirepository-2.0-dev gobject-introspection
+
+sudo apt install --assume-yes python3-numpy
+sudo apt install --assume-yes python3-dev
+
+mkdir venv
+python3 -m venv --system-site-packages venv/labsmore
+. venv/labsmore/bin/activate
+
+pip install pycairo
+pip install numpy
+pip install opencv-python-headless
+pip install distro
+pip install paramiko
+pip install pyzbar
+pip install json5 boto3 pygame psutil bitarray piexif
+pip install Flask # >=2.2.2
+pip install Pillow
+pip install pyserial
+pip install PyQt5
+pip install setuptools
+
+git clone https://github.com/Labsmore/pyuscope.git
+cd pyuscope
+python3 setup.py develop

--- a/setup_debian_toupcam.sh
+++ b/setup_debian_toupcam.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+sudo apt install --assume-yes \
+    gstreamer1.0-tools \
+    libgstreamer-plugins-base1.0-dev \
+    dpkg-dev \
+    devscripts \
+    libtool \
+    autoconf \
+    automake \
+    unzip
+
+mkdir toupcamsdk
+
+(cd toupcamsdk/
+  wget https://www.touptekphotonics.com/downloads/software/download.php?soft=toupcamsdk -O toupcamsdk.zip
+  unzip toupcamsdk.zip
+)
+sudo mv toupcamsdk /opt/
+
+(cd /opt/toupcamsdk/
+sudo cp linux/x64/libtoupcam.so /lib/x86_64-linux-gnu/
+sudo cp linux/udev/99-toupcam.rules  /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+)
+
+sudo ldconfig
+
+git clone https://github.com/JohnDMcMaster/gst-plugin-toupcam.git
+cd gst-plugin-toupcam
+./autogen.sh
+make
+
+sudo make install
+echo "export GST_PLUGIN_PATH=/usr/local/lib/gstreamer-1.0" >> ~/.profile
+
+# verify:
+GST_PLUGIN_PATH=/usr/local/lib/gstreamer-1.0 gst-inspect-1.0 toupcamsrc

--- a/uscope/gui/gstwidget.py
+++ b/uscope/gui/gstwidget.py
@@ -462,7 +462,7 @@ class GstVideoPipeline:
 
         For now this needs to be called early
         But with some tweaks it can be made dynamic
-        
+
         w/h: total canvas area available for all widgets we need to create
         """
 
@@ -642,9 +642,9 @@ class GstVideoPipeline:
         TODO: clean up queue architecture
         Probably need to add a seperate (optional) tee before and after videoconvert
         This will allow raw imaging but also share encoding for main + ROI
-        
-        
-        toupcamsource ! 
+
+
+        toupcamsource !
         """
 
         self.tee_vc = None

--- a/uscope/gui/gstwidget.py
+++ b/uscope/gui/gstwidget.py
@@ -291,7 +291,7 @@ class SinkxZoomableWidget(ArgusVideoWidget):
         if 0:
             # Set to full widget size (as opposed to usable widget area) so that border is added to center view
             # see caps filter add-borders=true
-            self.capsfilter.props.caps = Gst.Caps(
+            self.capsfilter.props.caps = Gst.Caps.from_string(
                 "video/x-raw,width=%u,height=%u" %
                 (widget_width, widget_height))
             # New caps => must reconfigure
@@ -673,7 +673,7 @@ class GstVideoPipeline:
         # Select the correct resolution from the camera
         # This is pre-crop so it must be the actual resolution
         raw_w, raw_h = self.ac.microscope.usc.imager.raw_wh()
-        self.raw_capsfilter.props.caps = Gst.Caps(
+        self.raw_capsfilter.props.caps = Gst.Caps.from_string(
             "video/x-raw,width=%u,height=%u" % (raw_w, raw_h))
         self.link_next_raw_element(self.raw_capsfilter)
 

--- a/uscope/imager/gst.py
+++ b/uscope/imager/gst.py
@@ -58,7 +58,7 @@ class GstCLIImager(Imager):
 
         self.raw_capsfilter = Gst.ElementFactory.make("capsfilter")
         assert self.raw_capsfilter is not None
-        self.raw_capsfilter.props.caps = Gst.Caps(
+        self.raw_capsfilter.props.caps = Gst.Caps.from_string(
             "video/x-raw,width=%u,height=%u" % (self.width, self.height))
         self.player.add(self.raw_capsfilter)
         if not self.source.link(self.raw_capsfilter):


### PR DESCRIPTION
I used setup_ubuntu as inspiration.   There are 2 scripts that need to be run.  I didn't like having the 
toupcamsrc script called from the main, so now you need to run 2 scripts.   Good enough for now.  I hope to get this packaged for Debian, which will then make it easy to install on RaspiOS and Ubuntu.

According to AI, Gst.Cap is shorthand for Gst.Caps.from_string( and the shortcut caused caused a problem so no more shorthand.